### PR TITLE
Fix approximate satisfaction issue with constraints that are missing the patch value

### DIFF
--- a/lib/solve/constraint.rb
+++ b/lib/solve/constraint.rb
@@ -169,6 +169,10 @@ module Solve
     def satisfies?(target_version)
       target_version = Version.new(target_version.to_s)
 
+      if target_version.pre_release? && !version.pre_release?
+        return false
+      end
+
       @compare_fun.call(self, target_version)
     end
 

--- a/lib/solve/version.rb
+++ b/lib/solve/version.rb
@@ -91,6 +91,10 @@ module Solve
       end
     end
 
+    def pre_release?
+      !!pre_release
+    end
+
     # @return [Integer]
     def pre_release_and_build_presence_score
       pre_release ? 0 : (build.nil? ? 1 : 2)

--- a/spec/unit/solve/constraint_spec.rb
+++ b/spec/unit/solve/constraint_spec.rb
@@ -256,6 +256,22 @@ describe Solve::Constraint do
       should satisfies(Solve::Version.new("1.0.0"))
     end
 
+    context "when the constraint contains a pre-release value" do
+      subject { Solve::Constraint.new(">= 1.2.3-alpha") }
+
+      it "is satisfied by pre-release versions" do
+        should satisfies("1.2.3-beta")
+      end
+    end
+
+    context "when the constraint does not contain a pre-release value" do
+      subject { Solve::Constraint.new(">= 1.2.3") }
+
+      it "is not satisfied by pre-release versions" do
+        should_not satisfies("1.2.3-beta")
+      end
+    end
+
     context "strictly greater than (>)" do
       subject { Solve::Constraint.new("> 1.0.0-alpha") }
 
@@ -295,7 +311,7 @@ describe Solve::Constraint do
       subject { Solve::Constraint.new("<= 1.0.0") }
 
       it { should satisfies("0.9.9+build") }
-      it { should satisfies("1.0.0-alpha") }
+      it { should_not satisfies("1.0.0-alpha") }
       it { should satisfies("1.0.0") }
       it { should_not satisfies("1.0.0+build") }
       it { should_not satisfies("1.0.1") }

--- a/spec/unit/solve/version_spec.rb
+++ b/spec/unit/solve/version_spec.rb
@@ -282,6 +282,18 @@ describe Solve::Version do
     end
   end
 
+  describe "#pre_release?" do
+    context "when a pre-release value is set" do
+      subject { described_class.new("1.2.3-alpha").pre_release? }
+      it { should be_true }
+    end
+
+    context "when no pre-release value is set" do
+      subject { described_class.new("1.2.3").pre_release? }
+      it { should be_false }
+    end
+  end
+
   describe "#to_s" do
     subject { Solve::Version.new("1.0.0-rc.1+build.1") }
 


### PR DESCRIPTION
This fixes an issue where `~> 1.2` would not satisfy `1.2.3`.

It also addresses an issue where pre-release versions would satisfy constraints which do not contain a pre-release segment.
