### PR TITLE
don't return nil patch version in to_s

### DIFF
--- a/lib/solve/constraint.rb
+++ b/lib/solve/constraint.rb
@@ -188,7 +188,8 @@ module Solve
 
     def to_s
       str = operator
-      str += " #{major}.#{minor}.#{patch}"
+      str += " #{major}.#{minor}"
+      str += ".#{patch}" if patch
       str += "-#{pre_release}" if pre_release
       str += "+#{build}" if build
       str


### PR DESCRIPTION
Chef cookbook metadata requires supports version in the form of x.y,
ridley errored out if the supports version was not in the form of x.y.,
which is not supported by knife.

only include the patch version if it is not nil, to avoid the returning of
x.y., return x.y instead

``` bash
➜  yum git:(master) grep supports metadata.rb
  supports os, ">= 5.0"
➜  yum git:(master) berks upload
Using yum (2.2.1) at path: '/Users/bhouse/yum'
Using minitest-handler (0.2.1)
Using yum_test (1.0.0) at path: '/Users/bhouse/yum/test/cookbooks/yum_test'
Using chef_handler (1.1.4)
Uploading yum (2.2.1) to: 'https://<chef-server-url>:443/'
Ridley::Errors::HTTPBadRequest: {"error":["Invalid value '>= 5.0.' for metadata.platforms"]}
```
