### PR TITLE
Remove JSON as a dependency - it's included in Ruby

### DIFF
--- a/solve.gemspec
+++ b/solve.gemspec
@@ -16,6 +16,4 @@ Gem::Specification.new do |s|
   s.require_paths         = ["lib"]
   s.version               = Solve::VERSION
   s.required_ruby_version = ">= 1.9.1"
-
-  s.add_dependency 'json'
 end


### PR DESCRIPTION
This is one of the last remnants of the JSON gem in Berkshelf

/cc @reset @ivey @justincampbell
