### PR TITLE
Add better #inspect output for Version and Constraint

### DIFF
--- a/lib/solve/constraint.rb
+++ b/lib/solve/constraint.rb
@@ -204,6 +204,10 @@ module Solve
     end
     alias_method :eql?, :==
 
+    def inspect
+      "#<#{self.class.to_s} #{to_s}>"
+    end
+
     def to_s
       str = "#{operator} #{major}"
       str += ".#{minor}" if minor

--- a/lib/solve/version.rb
+++ b/lib/solve/version.rb
@@ -127,7 +127,7 @@ module Solve
     end
 
     def inspect
-      to_s
+      "#<#{self.class.to_s} #{to_s}>"
     end
 
     def to_s


### PR DESCRIPTION
It's really confusing when inspecting a Version or VersionConstraint that the output appears as a string.
