### PR TITLE
Prevent backtrack loops

### DIFF
--- a/lib/solve/solver.rb
+++ b/lib/solve/solver.rb
@@ -260,6 +260,7 @@ module Solve
 
       def add_dependencies(dependencies, source)
         dependencies.each do |dependency|
+          next if (source.respond_to?(:name) && dependency.name == source.name)
           Solve.tracer.add_constraint(dependency, source)
           variable_table.add(dependency.name, source)
           constraint_table.add(dependency, source)

--- a/spec/acceptance/solutions_spec.rb
+++ b/spec/acceptance/solutions_spec.rb
@@ -114,6 +114,19 @@ describe "Solutions" do
                       "D" => "1.0.0")
   end
 
+  it "fails with a self dependency" do
+    graph = Solve::Graph.new
+
+    graph.artifacts("bottom", "1.0.0")
+    graph.artifacts("middle", "1.0.0").depends("top", "= 1.0.0").depends("middle")
+
+    demands = [["bottom", "1.0.0"],["middle", "1.0.0"]]
+
+    expect { Solve.it!(graph, demands, { :sorted => true  } ) }.to raise_error { |error|
+      error.should be_a(Solve::Errors::NoSolutionError)
+    }
+  end
+
   it "gives an empty solution when there are no demands" do
     graph = Solve::Graph.new
     result = Solve.it!(graph, [])


### PR DESCRIPTION
If an artifact has a dependency on itself it will cause backtrack to loop indefinitely as it resets its own possible values. If this is found, just ignore the dependency and continue on.

Note, this is only an issue when Solve must backtrack.
