### PR TITLE
Increase solver timeout or allow timeout to be configured dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ NOTE: This will raise Solve::Errors::UnsortableSolutionError if the solution con
 
     Solve.it!(graph, ['nginx', '>= 0.100.0'], sorted: true)
 
+### Increasing the solver's timeout
+
+By default the solver will wait 10 seconds before giving up on finding a solution. Under certain conditions a graph may be too complicated to solve within the alotted time. To increase the timeout you can set the "SOLVE_TIMEOUT" environment variable to the amount of seconds desired.
+
+    $ export SOLVE_TIMEOUT=30
+
+This will set the timeout to 30 seconds instead of 10 seconds.
+
 ## Authors
 
 * [Jamie Winsor](https://github.com/reset) (<jamie@vialstudios.com>)

--- a/lib/solve/solver.rb
+++ b/lib/solve/solver.rb
@@ -4,6 +4,13 @@ require_relative 'solver/serializer'
 
 module Solve
   class Solver
+    class << self
+      def timeout
+        seconds = 10 unless seconds = ENV["SOLVE_TIMEOUT"]
+        seconds.to_i * 1_000
+      end
+    end
+
     # Graph object with references to all known artifacts and dependency
     # constraints.
     #
@@ -24,10 +31,10 @@ module Solve
     # @param [Array<String>, Array<Array<String, String>>] demands
     # @param [#say] ui
     def initialize(graph, demands, ui = nil)
-      @ds_graph = DepSelector::DependencyGraph.new
-      @graph = graph
+      @ds_graph      = DepSelector::DependencyGraph.new
+      @graph         = graph
       @demands_array = demands
-      @timeout_ms = 1_000
+      @timeout_ms    = self.class.timeout
     end
 
     # The problem demands given as Demand model objects

--- a/spec/unit/solve/solver_spec.rb
+++ b/spec/unit/solve/solver_spec.rb
@@ -1,6 +1,24 @@
 require 'spec_helper'
 
 describe Solve::Solver do
+  describe "ClassMethods" do
+    describe "::timeout" do
+      subject { described_class.timeout }
+
+      it "returns 10,000 by default" do
+        expect(subject).to eql(10_000)
+      end
+
+      context "when the SOLVE_TIMEOUT env variable is set" do
+        before { ENV.stub(:[]).with("SOLVE_TIMEOUT") { "30" } }
+
+        it "returns the value multiplied by a thousand" do
+          expect(subject).to eql(30_000)
+        end
+      end
+    end
+  end
+
   let(:graph) { double(Solve::Graph) }
   let(:demands) { [["mysql"], ["nginx"]] }
   subject(:solver) { described_class.new(graph, demands) }


### PR DESCRIPTION
When working with berkshelf 3 under a large environment, the default timeout of 1s does not provide enough time to resolve dependency conflicts.

```
$ berks install
Resolving cookbook dependencies...
Fetching 'foo' from source at cookbooks/foo
Fetching cookbook index from http://localhost:26200...
There is a dependency conflict, but the solver could not determine the precise cause in the time allotted.
```

For testing purposes, increasing the hardcoded limit in `lib/solve/solver.rb` from `1_000ms` to `10_000ms` results in the conflict being found.

```
$ berks install
Resolving cookbook dependencies...
Fetching 'foo' from source at cookbooks/foo
Fetching cookbook index from http://localhost:26200...
Unable to satisfy constraints on package bar due to solution constraint (fake ~> 1.0). 
```
