### PR TITLE
Make NoSolutionError constraints match format of input

### DIFF
--- a/lib/solve/errors.rb
+++ b/lib/solve/errors.rb
@@ -43,7 +43,8 @@ module Solve
         s << "#{@message}\n"
         s << "Missing artifacts: #{missing_artifacts.join(',')}\n" unless missing_artifacts.empty?
         unless constraints_excluding_all_artifacts.empty?
-          s << "Constraints that match no available version: #{constraints_excluding_all_artifacts.join(',')}\n"
+	  pretty = constraints_excluding_all_artifacts.map { |constraint| "(#{constraint[0]} #{constraint[1]})" }.join(',')
+          s << "Constraints that match no available version: #{pretty}\n"
         end
         s << "Demand that cannot be met: #{unsatisfiable_demand}\n" if unsatisfiable_demand
         unless artifacts_with_no_satisfactory_version.empty?

--- a/lib/solve/solver.rb
+++ b/lib/solve/solver.rb
@@ -146,7 +146,7 @@ module Solve
         end
 
         constrained_to_no_versions = e.constrained_to_no_versions.inject([]) do |list, constraint|
-          list << constraint.to_s
+          list << [constraint.package.name, constraint.constraint.to_s]
         end
 
         raise Solve::Errors::NoSolutionError.new(


### PR DESCRIPTION
When setting constraints to be resolved, they are specified like `["package", "constraint"]`
However the NoSolutionError was outputing them as a string like `"(package constraint)"`
which makes it much harder to programmatically determine what constraints had no
solution. It makes sense to output that in the same format as inputted.

In the `NoSolutionError#to_s` method, I am reformatting into the original string. This causes the appropriate specs to still pass. (However I noticed 2 specs were failing before I made any changes.)
