### PR TITLE
Readme example does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Dependencies can be chained, too
 
 And now solve the graph with some demands
 
-    Solve.it!(graph, ['nginx', '>= 0.100.0'])
+    Solve.it!(graph, [['nginx', '>= 0.100.0']])
 
 Or, if you want a topologically sorted solution
 NOTE: This will raise Solve::Errors::UnsortableSolutionError if the solution contains a cycle (which can happen with ruby packages)
 
-    Solve.it!(graph, ['nginx', '>= 0.100.0'], sorted: true)
+    Solve.it!(graph, [['nginx', '>= 0.100.0']], sorted: true)
 
 ### Increasing the solver's timeout
 


### PR DESCRIPTION
``` text
irb(main):018:0> graph = Solve::Graph.new
=> #<Solve::Graph:0x007fe83c3f67f0 @artifacts={}, @artifacts_by_name={}>
irb(main):019:0> graph.artifact("nginx", "1.0.0")
=> #<Solve::Artifact:0x007fe83c3ed128 @graph=#<Solve::Graph:0x007fe83c3f67f0 @artifacts={"nginx-1.0.0"=>#<Solve::Artifact:0x007fe83c3ed128 ...>}, @artifacts_by_name={"nginx"=>[#<Solve::Artifact:0x007fe83c3ed128 ...>]}>, @name="nginx", @version=#<Semverse::Version 1.0.0>, @dependencies={}>
irb(main):020:0> Solve.it!(graph, ['nginx', '>= 0.100.0'])
Solve::Errors::NoSolutionError: Required artifacts do not exist at the desired version
Missing artifacts: >= 0.100.0

    from /Users/jperry/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/solve-1.2.0/lib/solve/solver.rb:152:in `report_invalid_constraints_error'
    from /Users/jperry/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/solve-1.2.0/lib/solve/solver.rb:90:in `rescue in solve_demands'
    from /Users/jperry/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/solve-1.2.0/lib/solve/solver.rb:87:in `solve_demands'
    from /Users/jperry/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/solve-1.2.0/lib/solve/solver.rb:62:in `resolve'
    from /Users/jperry/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/solve-1.2.0/lib/solve.rb:32:in `it!'
    from (irb):20
    from /Users/jperry/.rbenv/versions/2.1.0/bin/irb:11:in `<main>'
```
