### PR TITLE
Set default engine ivar on the right object

### DIFF
--- a/lib/solve.rb
+++ b/lib/solve.rb
@@ -10,11 +10,13 @@ module Solve
   require_relative 'solve/ruby_solver'
   require_relative 'solve/gecode_solver'
 
+  # We have to set the default engine here, it gets set on the wrong object if
+  # we put this in the metaclass context below.
+  @engine = :ruby
+
   class << self
     # @return [Solve::Formatter]
     attr_reader :tracer
-
-    @engine = :ruby
 
     # Returns the currently configured engine.
     # @see #engine=
@@ -73,4 +75,6 @@ module Solve
 
     private :solver_for_engine
   end
+
 end
+


### PR DESCRIPTION
Just tried this out in ChefDK, and the default engine wasn't set correctly. Not exactly sure what's going on, maybe the ivar was set on the metaclass object instead of the class?

I couldn't figure out off-hand how to make a regression test (because we call `Solve.engine=` in the setup part of the tests), but I'm happy to implement one if we can figure it out.