### PR TITLE
Bump version to 2.0.3 for release

### DIFF
--- a/lib/solve/version.rb
+++ b/lib/solve/version.rb
@@ -1,3 +1,3 @@
 module Solve
-  VERSION = "2.0.2"
+  VERSION = "2.0.3"
 end


### PR DESCRIPTION
I opted for a patch version bump as the changes to Molinillo should be transparent to end users except for bug fixes and perf improvements. The Molinillo version bump is the only substantive change; other than that there was a change to the travis.ci configuration.

This project doesn't have a changelog, so there was nothing to do there.

@reset look good?