### PR TITLE
lets try letting molinillo float

### DIFF
--- a/solve.gemspec
+++ b/solve.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.1.0"
 
   s.add_dependency "semverse",     ">= 1.1", "< 3.0"
-  s.add_dependency "molinillo",    "~> 0.4"
+  s.add_dependency "molinillo",    ">= 0.5"
 
   s.add_development_dependency 'thor'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This allows solve to be compatible with a wider range of future molinillo versions.

Version pinning should probably be done upstream in the "application" (either berkshelf or chef-dk).

This will address errors like this from using outdated versions of molinillo:

https://github.com/berkshelf/berkshelf/issues/1616

Since we're already not requiring perfectly identical behavior between the ruby and gecode depsolvers, and we don't have any requirement for perfect bug-compatibility between different versions of chef-dk and chef-dk inherently pins the depsolver to a consistent bug-compatible behavior I don't see any inherent downside caused by slightly different depsolving, while this allows us to pick up bugfixes so we don't become pinned on buggy versions (presumably molinillo should become less buggy over time rather than more buggy).

Its possible this breaks horribly at some point in the future when molinillo ships a breaking API change and builds start failing -- but this already pours into whatever our Gemfile.lock and gem-bumping strategy is.