### PR TITLE
Cope with nil-payload vertices in the solved graph.

### DIFF
--- a/lib/solve/ruby_solver.rb
+++ b/lib/solve/ruby_solver.rb
@@ -77,7 +77,7 @@ module Solve
       solution =  solved_graph.map(&:payload)
 
       unsorted_solution = solution.inject({}) do |stringified_soln, artifact|
-        stringified_soln[artifact.name] = artifact.version.to_s
+        stringified_soln[artifact.name] = artifact.version.to_s if artifact
         stringified_soln
       end
 


### PR DESCRIPTION
 This should be fixed in Molinillo 0.6.0 but the workaround should be harmless to leave in.

This fixes the "nil has no method `name`" errors from Berks when using the Ruby solver or from the policyfile solver.