### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/solve/gecode_solver.rb
+++ b/lib/solve/gecode_solver.rb
@@ -1,5 +1,5 @@
 require "set"
-require "solve/errors"
+require_relative "errors"
 require_relative "solver/serializer"
 
 module Solve

--- a/lib/solve/solver/serializer.rb
+++ b/lib/solve/solver/serializer.rb
@@ -1,5 +1,5 @@
 require "json"
-require "solve/graph"
+require_relative "../graph"
 
 module Solve
 


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>