### PR TITLE
Convert a few complex require calls to require_relative

### DIFF
--- a/solve.gemspec
+++ b/solve.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path("../lib/solve/version", __FILE__)
+require_relative "lib/solve/version"
 
 Gem::Specification.new do |s|
   s.authors               = ["Jamie Winsor", "Andrew Garson", "Thibaud Guillaume-Gentil"]

--- a/spec/acceptance/benchmark.rb
+++ b/spec/acceptance/benchmark.rb
@@ -1,8 +1,8 @@
 require "benchmark"
 require "solve"
 require "solve/gecode_solver"
-require File.expand_path("../large_graph_no_solution", __FILE__)
-require File.expand_path("../opscode_ci_graph", __FILE__)
+require_relative "large_graph_no_solution"
+require_relative "opscode_ci_graph"
 
 PROBLEM = OpscodeCiGraph
 # PROBLEM = LargeGraphNoSolution


### PR DESCRIPTION
Avoid needing to expand path to pass in an abs path to require.

Signed-off-by: Tim Smith <tsmith@chef.io>